### PR TITLE
Update funcLib.py

### DIFF
--- a/funcLib.py
+++ b/funcLib.py
@@ -27,7 +27,7 @@ def getNewsIOArticles(q, articleslimit = 2, category = 'top'):
     newsApiKey = os.getenv("NEWSDATAKEY")
     if newsApiKey is None:
         raise ValueError('NEWSDATAKEY is missing')
-    requesturl = 'https://newsdata.io/api/1/news?'+'apikey='+newsApiKey+'&language=en' #+"&country=au,nz"
+    requesturl = 'https://newsdata.io/api/1/latest?'+'apikey='+newsApiKey+'&language=en' #+"&country=au,nz"
     #requesturl +='&timeframe=24'#hours #disabled as it is only available on paid plans
     requesturl +=f'&category={category}'
     requesturl += ('&q='+q) if q is not None else ''


### PR DESCRIPTION
We are writing to inform you of an important update to our NewsData.io API. To enhance our service and better align with our naming conventions, we are changing the name of our "news" endpoint to "latest" endpoint.

Key Details:
Both "news" and "latest" endpoints will remain functional, ensuring uninterrupted access to our news data. The "news" endpoint will be deprecated by 15 Dec 2024. After this period, only the "latest" endpoint will remain operational.